### PR TITLE
Update to a newer Alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM alpine:3.15
+FROM alpine:3.17
 RUN apk add --no-cache bash curl bind-tools tcptraceroute whois busybox-extras netcat-openbsd lynx


### PR DESCRIPTION
Update Alpine (currently 3.15) to the newer version 3.17.